### PR TITLE
Adding target name to output path for plugin executable

### DIFF
--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -24,6 +24,7 @@ load(
 )
 load(
     "@build_bazel_rules_swift//swift/internal:feature_names.bzl",
+    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE__SUPPORTS_MACROS",
 )
 load(
@@ -119,6 +120,15 @@ def _swift_compiler_plugin_impl(ctx):
         feature_configuration = feature_configuration,
     )
 
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
+    ):
+        # Making executable in a folder to avoid naming collisions
+        name = "{}/{}".format(ctx.label.name, ctx.label.name)
+    else:
+        name = ctx.label.name
+
     binary_linking_outputs = register_link_binary_action(
         actions = ctx.actions,
         additional_inputs = ctx.files.swiftc_inputs,
@@ -126,7 +136,7 @@ def _swift_compiler_plugin_impl(ctx):
         cc_feature_configuration = cc_feature_configuration,
         compilation_outputs = cc_compilation_outputs,
         deps = deps,
-        name = ctx.label.name,
+        name = name,
         output_type = "executable",
         stamp = ctx.attr.stamp,
         owner = ctx.label,


### PR DESCRIPTION
Adding `target_name` to output path of swift plugin executable. Feature covered by `SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT` flag.

Without this change and `SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT` enabled, we have naming collisions as bazel makes executable file on root folder, and in this root folder we make our `target_name` folder with all other files like: swiftinterface, headers, etc. 
By adding this change, we put executable in same `target_name` folder with all other generated files