### PR TITLE
Warnings as errors

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -88,6 +88,7 @@ bzl_library(
         ":utils",
         ":vfsoverlay",
         ":wmo",
+        "//swift/toolchains/config:default_warnings_as_errors",
         "//swift:providers",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:sets",

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -64,6 +64,7 @@ load(
     "get_cc_feature_configuration",
     "is_feature_enabled",
     "upcoming_and_experimental_features",
+    "warnings_as_errors_from_features",
 )
 load(":module_maps.bzl", "write_module_map")
 load(
@@ -627,6 +628,11 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
     upcoming_features, experimental_features = upcoming_and_experimental_features(
         feature_configuration = feature_configuration,
     )
+
+    warnings_as_errors = warnings_as_errors_from_features(
+        feature_configuration = feature_configuration,
+    )
+
     prerequisites = struct(
         additional_inputs = additional_inputs,
         always_include_headers = is_feature_enabled(
@@ -655,6 +661,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         transitive_swiftmodules = transitive_swiftmodules,
         upcoming_features = upcoming_features,
         user_compile_flags = copts,
+        warnings_as_errors = warnings_as_errors,
         vfsoverlay_file = vfsoverlay_file,
         vfsoverlay_search_path = _SWIFTMODULES_VFS_ROOT,
         workspace_name = workspace_name,

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -310,6 +310,24 @@ def upcoming_and_experimental_features(feature_configuration):
 
     return (upcoming, experimental)
 
+def warnings_as_errors_from_features(feature_configuration):
+    """Extracts the diagnostic IDs to treat as errors in post-processing.
+
+    Args:
+        feature_configuration: The Swift feature configuration.
+
+    Returns:
+        The `list` of diagnostic IDs to treat as errors.
+    """
+    prefix = "swift.werror."
+    warnings_as_errors = []
+
+    for feature in feature_configuration._enabled_features:
+        if feature.startswith(prefix):
+            warnings_as_errors.append(feature[len(prefix):])
+
+    return warnings_as_errors
+
 def _check_allowlists(
         *,
         allowlists,

--- a/swift/toolchains/config/BUILD
+++ b/swift/toolchains/config/BUILD
@@ -74,6 +74,11 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "default_warnings_as_errors",
+    srcs = ["default_warnings_as_errors.bzl"],
+)
+
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -226,6 +226,13 @@ def compile_action_configs(
             features = [SWIFT_FEATURE_EMIT_SWIFTINTERFACE],
         ),
         ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [
+                add_arg("-debug-diagnostic-names"),
+                _warnings_as_errors_configurator,
+            ],
+        ),
+        ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
                 SWIFT_ACTION_DERIVE_FILES,
@@ -1362,6 +1369,10 @@ def _emit_module_path_configurator(prerequisites, args):
 def _emit_module_interface_path_configurator(prerequisites, args):
     """Adds the `.swiftinterface` output path to the command line."""
     args.add("-emit-module-interface-path", prerequisites.swiftinterface_file)
+
+def _warnings_as_errors_configurator(prerequisites, args):
+    """Adds flags to treat specific warnings as errors to the command line."""
+    args.add_all(prerequisites.warnings_as_errors, format_each = "-Xwrapped-swift=-warning-as-error=%s")
 
 def _emit_private_module_interface_path_configurator(prerequisites, args):
     """Adds the `.private.swiftinterface` output path to the command line."""

--- a/swift/toolchains/config/default_warnings_as_errors.bzl
+++ b/swift/toolchains/config/default_warnings_as_errors.bzl
@@ -1,0 +1,29 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manages the default list of warnings that are upgraded to errors."""
+
+visibility([
+    "//swift/toolchains/...",
+])
+
+_WARNINGS_AS_ERRORS_IDENTIFIERS = [
+]
+
+def default_warnings_as_errors_features():
+    """Returns features to upgrade warnings to errors."""
+    return [
+        "swift.werror.{}".format(id)
+        for id in _WARNINGS_AS_ERRORS_IDENTIFIERS
+    ]

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -97,6 +97,10 @@ load(
     "symbol_graph_action_configs",
 )
 load("//swift/toolchains/config:tool_config.bzl", "ToolConfigInfo")
+load(
+    "@build_bazel_rules_swift//swift/toolchains/config:default_warnings_as_errors.bzl",
+    "default_warnings_as_errors_features",
+)
 
 # TODO: Remove once we drop bazel 7.x
 _OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")
@@ -630,6 +634,7 @@ def _xcode_swift_toolchain_impl(ctx):
         # `InternalImportsByDefault`.
         "swift.experimental.AccessLevelOnImport",
     ])
+    requested_features.extend(default_warnings_as_errors_features())
 
     if _is_xcode_at_least_version(xcode_config, "14.3"):
         requested_features.append(SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES)

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "tools/common/bazel_substitutions.h"
 #include "tools/common/temp_file.h"
@@ -122,6 +123,13 @@ class SwiftRunner {
   std::vector<std::string> ProcessArguments(
       const std::vector<std::string> &args);
 
+  // Upgrade any of the requested warnings to errors and then print all of the
+  // diagnostics to the given stream. Updates the exit code if necessary (to
+  // turn a previously successful compilation into a failing one).
+  void ProcessDiagnostics(std::string stderr_output,
+                          std::ostream &stderr_stream, 
+                          int &exit_code);
+
   // A mapping of Bazel placeholder strings to the actual paths that should be
   // substituted for them. Supports Xcode resolution on Apple OSes.
   bazel_rules_swift::BazelPlaceholderSubstitutions
@@ -176,6 +184,10 @@ class SwiftRunner {
   // `-index-store-path`. After running `swiftc` `index-import` copies relevant
   // index outputs into the `index_store_path` to integrate outputs with Bazel.
   std::string global_index_store_import_path_;
+
+  // A set containing the diagnostic IDs that should be upgraded from warnings
+  // to errors by the worker.
+  std::set<std::string> warnings_as_errors_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_SWIFT_RUNNER_H_


### PR DESCRIPTION
Adapted commit from rules_swift upstream branch: https://github.com/bazelbuild/rules_swift/commit/66a01374d9ddd087e16f7c81515ee31c031fb7af

Description:

Add the feature swift.werror.<diagnostic-name> to selectively allow certain warnings from the Swift compiler to be treated as errors.

The feature can be specified multiple times, with different diagnostic names.

The prefix `swift.werror...` is meant to evoke the `-Werror` Clang flag; `swift.warning_as_error...` and other variations felt too verbose.

This works by using the `-debug-diagnostic-names` flag to print the symbolic name of the diagnostic at the end of the message, in square brackets. Then the worker process intercepts stderr and looks for diagnostics with matching names, and modifies the message and exit code if there's a match.